### PR TITLE
Using Array.prototype.slice.call instead of lodash toArray

### DIFF
--- a/lib/rx.easing.js
+++ b/lib/rx.easing.js
@@ -1,4 +1,3 @@
-var _  = require('lodash');
 var Rx = require('rx');
 
 var Observable = Rx.Observable;
@@ -58,7 +57,7 @@ function make_ease_observable(easing_func) {
 	
 	return function(begin, end, duration) {
 		
-		var args = _.toArray(arguments);
+		var args = Array.prototype.slice.call(arguments);
 		
 		// The easing functions use the difference
 		// between the start and end values.
@@ -75,7 +74,7 @@ function curry_ease_time(easing_func) {
 	
 	return function() {
 		
-		var args = _.toArray(arguments);
+		var args = Array.prototype.slice.call(arguments);
 		
 		return function(time) {
 			return easing_func.apply(null, [time].concat(args));

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "easing"
   ],
   "dependencies": {
-    "lodash": "*",
     "rx": "*",
     "rx-dom": "*"
   },


### PR DESCRIPTION
Removed lodash dependency by replacing _.toArray with Array.prototype.slice.call
